### PR TITLE
fix nil comparison with repairCost & guild repair

### DIFF
--- a/AutoSeller.lua
+++ b/AutoSeller.lua
@@ -1204,13 +1204,8 @@ local autoRepair = function()
 
 			for i, repairSlot in ipairs(RepairSlots) do
 				local hasItem, hasCooldown, repairCost = tooltipScanner:SetInventoryItem("player", repairSlot:GetID())
-				local hasRepairCost = false
 
-				if repairCost then
-					hasRepairCost = repairCost <= GetMoney()
-				end
-
-				if (hasItem and hasRepairCost) then
+				if (hasItem and repairCost and repairCost <= GetMoney()) then
 					repairAllCost = repairAllCost - repairCost
 					repairSlot:Click()
 

--- a/AutoSeller.lua
+++ b/AutoSeller.lua
@@ -1204,8 +1204,13 @@ local autoRepair = function()
 
 			for i, repairSlot in ipairs(RepairSlots) do
 				local hasItem, hasCooldown, repairCost = tooltipScanner:SetInventoryItem("player", repairSlot:GetID())
+				local hasRepairCost = false
 
-				if (hasItem and repairCost <= GetMoney()) then
+				if repairCost then
+					hasRepairCost = repairCost <= GetMoney()
+				end
+
+				if (hasItem and hasRepairCost) then
 					repairAllCost = repairAllCost - repairCost
 					repairSlot:Click()
 


### PR DESCRIPTION
seems like the repairCost result of GameTooltip:SetInventoryItem can be nil, probably due an indestructible item